### PR TITLE
Strategies for a single request

### DIFF
--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -264,6 +264,7 @@ module Warden
       _run_strategies_for(scope, args)
 
       if winning_strategy && winning_strategy.user
+        opts[:store] = opts.fetch(:store, winning_strategy.store?)
         set_user(winning_strategy.user, opts.merge!(:event => :authentication))
       end
 

--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -98,6 +98,12 @@ module Warden
         !!@halted
       end
 
+      # Checks to see if a strategy should result in a permanent login
+      # :api: public
+      def store?
+        true
+      end
+
       # A simple method to return from authenticate! if you want to ignore this strategy
       # :api: public
       def pass; end

--- a/spec/helpers/strategies/single.rb
+++ b/spec/helpers/strategies/single.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+Warden::Strategies.add(:single) do
+  def authenticate!
+    request.env['warden.spec.strategies'] ||= []
+    request.env['warden.spec.strategies'] << :single
+    success!("Valid User")
+  end
+  
+  def store?
+    false
+  end
+end

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -269,6 +269,19 @@ describe Warden::Proxy do
       setup_rack(app).call(env)
     end
 
+    it "should not store user if strategy isn't meant for permanent login" do
+      env = env_with_params("/")
+      session = Warden::SessionSerializer.new(env)
+      app = lambda do |env|
+        env['warden'].authenticate(:single)
+        env['warden'].should be_authenticated
+        env['warden'].user.should == "Valid User"
+        session.should_not be_stored(:default)
+        valid_response
+      end
+      setup_rack(app).call(env)
+    end
+
   end
 
   describe "set user" do


### PR DESCRIPTION
I found it odd that Devise's Token `TokenAuthenticatable` granted a permanent login - I expected it that it would authorize a single request only, not performing a permanent login. When I tried to create my own strategy I noticed that Warden had a `set_user(user, :store => false)` method, but there was no way to set the `:store` option from within a strategy.

I added a `store?` method to the base strategy (default: `true`) which you can let return `false` when implementing your own strategy to prevent saving to the session. Providing a `:store` option to `set_user` will always take precedence over `store?`.
