### PR TITLE
Minor tweak for LoadError in warden.gemspec and for frozen string in version.rb

### DIFF
--- a/lib/warden/version.rb
+++ b/lib/warden/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Warden
-  VERSION = "1.0.4".freeze
+  VERSION = "1.0.4"
 end

--- a/warden.gemspec
+++ b/warden.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-require 'lib/warden/version'
+require './lib/warden/version'
 
 Gem::Specification.new do |s|
   s.name = %q{warden}


### PR DESCRIPTION
Bundle install will not work unless I:
1. Add relative path in `warden.gemspec require './lib/warden/version'`
2. unfreeze version string in `version.rb` to get bundler to work

This may be more a function of my local installation and very recently updated everything (as in, an hour ago), but I just couldn't get bundle install to work without these tweaks. Hopefully, it's just something I've misconfigured on my end, but if not, perhaps this might help someone else.

Also, if this really is a bug, and should be filed as a bug, please let me know and I'll do that.
