### PR TITLE
made warden dev ready for ruby 1.9.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    warden (1.0.7)
+    warden (1.1.0)
       rack (>= 1.0)
 
 GEM

--- a/spec/helpers/request_helper.rb
+++ b/spec/helpers/request_helper.rb
@@ -15,7 +15,7 @@ module Warden::Spec
       opts[:failure_app]         ||= failure_app
       opts[:default_strategies]  ||= [:password]
       opts[:default_serializers] ||= [:session]
-      blk = opts[:configurator] || lambda{}
+      blk = opts[:configurator] || proc{}
 
       Rack::Builder.new do
         use opts[:session] || Warden::Spec::Helpers::Session

--- a/warden.gemspec
+++ b/warden.gemspec
@@ -4,7 +4,7 @@ require './lib/warden/version'
 
 Gem::Specification.new do |s|
   s.name = %q{warden}
-  s.version = Warden::VERSION
+  s.version = Warden::VERSION.dup
   s.authors = ["Daniel Neighman"]
   s.date = %q{2011-07-27}
   s.email = %q{has.sox@gmail.com}


### PR DESCRIPTION
hi,

i wanted to understand wardens implementation and ran into two problems when setting the project up on my mac. i noticed two problems that are related to the changes from ruby 1.8 to 1.9

firstly, it complaint when sending strip! to warden's version string in the gemspec because it was freezed. looking at device's way to do it i changed line 7 in warden's gemspec to dup the string

s.version = Warden::VERSION.dup

secondly, the specs did complain about wrong number of arguments for some methods and failed. turned out that the single argument that is passed to a rack application's call method gets also applied to a nested block that was created with lambda{} in ruby 1.9. so i changed

blk = opts[:configurator] || lambda{} 

to

blk = opts[:configurator] || proc{}

which works fine and passes all test in 1.9 now. nevertheless, i don't know whether the change breaks anything i might not understand at the moment. but since it's just a test helper method it shouldn't be much of a problem if it did.

sincerely,
linki
