### PR TITLE
Use Warden without session system

### DIFF
--- a/lib/warden/session_serializer.rb
+++ b/lib/warden/session_serializer.rb
@@ -21,11 +21,13 @@ module Warden
     end
 
     def store(user, scope)
+      return unless session
       return unless user
       session[key_for(scope)] = serialize(user)
     end
 
     def fetch(scope)
+      return unless session
       key = session[key_for(scope)]
       return nil unless key
       user = deserialize(key)


### PR DESCRIPTION
I use warden as authentication system in an API only providing authentication via HTTP_BASIC_AUTH, This patch stops warden from trowing exceptions if there is no session object around.
