### PR TITLE
Adding run_callbacks option to user.

### DIFF
--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -178,16 +178,30 @@ module Warden
     #   # with scope
     #   env['warden'].user(:admin)
     #
+    #   # as a Hash
+    #   env['warden'].user(:scope => :admin)
+    #
     #   # with default scope and run_callbacks option
-    #   env['warden'].user(nil, :run_callbacks => false)
+    #   env['warden'].user(:run_callbacks => false)
+    #
+    #  # with a scope and run_callbacks option
+    #  env['warden'].user(:scope => :admin, :run_callbacks => true)
+    #
     # :api: public
-    def user(scope = @config.default_scope, opts = {})
-      scope ||= @config.default_scope
+    def user(argument = nil)
+      scope = case argument
+        when NilClass then @config.default_scope
+        when Hash then (argument[:scope] || @config.default_scope)
+        when Symbol then argument
+        else argument
+      end
+      
+      opts = argument.is_a?(Hash) ? argument : { :run_callbacks => true }
 
       @users[scope] ||= begin
         user = session_serializer.fetch(scope)
-        
-        opts.merge!({:scope => scope, :event => :fetch})
+
+        opts.merge!({:scope => scope, :event => :fetch })
 
         set_user(user, opts) if user
       end
@@ -332,6 +346,6 @@ module Warden
         raise "Invalid strategy #{name}"
       end
     end
-
   end # Proxy
+
 end # Warden

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -369,7 +369,7 @@ describe Warden::Proxy do
     it "should not run the callbacks when :run_callbacks is false" do
       app = lambda do |env|
         env['warden'].manager.should_not_receive(:_run_callbacks)
-        env['warden'].authenticate(:pass, :run_callbacks => false)
+        env['warden'].authenticate(:run_callbacks => false, :scope => :pass)
         valid_response
       end
       setup_rack(app).call(@env)
@@ -378,7 +378,7 @@ describe Warden::Proxy do
     it "should run the callbacks when :run_callbacks is true" do
       app = lambda do |env|
         env['warden'].manager.should_receive(:_run_callbacks)
-        env['warden'].authenticate(:pass, :run_callbacks => true)
+        env['warden'].authenticate(:pass)
         valid_response
       end
       setup_rack(app).call(@env)
@@ -444,7 +444,7 @@ describe Warden::Proxy do
         it "should not call run_callbacks when we pass a :run_callback => false" do
           app = lambda do |env|
             env['warden'].manager.should_not_receive(:_run_callbacks)
-            env['warden'].user(nil, :run_callbacks => false)
+            env['warden'].user(:run_callbacks => false)
             valid_response
           end
           setup_rack(app).call(@env)
@@ -453,7 +453,7 @@ describe Warden::Proxy do
         it "should call run_callbacks when we pass a :run_callback => true" do
           app = lambda do |env|
             env['warden'].manager.should_receive(:_run_callbacks)
-            env['warden'].user(nil, :run_callbacks => true)
+            env['warden'].user(:run_callbacks => true)
             valid_response
           end
           setup_rack(app).call(@env)


### PR DESCRIPTION
Added the possibility to specify if you want the callbacks to be run when fetching a user in Proxy class.

To avoid default scope hardcoding, I also made possible to send the scope through a Hash among with the run_callbacks option.
