### PR TITLE
Speedup user lookup by also caching if user could not be found

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 PATH
   remote: .
   specs:
-    warden (1.1.1)
+    warden (1.2.0)
       rack (>= 1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
+    diff-lcs (1.1.3)
     rack (1.3.0)
     rack-test (0.6.0)
       rack (>= 1.0)
     rake (0.8.7)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
+    rspec (2.10.0)
+      rspec-core (~> 2.10.0)
+      rspec-expectations (~> 2.10.0)
+      rspec-mocks (~> 2.10.0)
+    rspec-core (2.10.1)
+    rspec-expectations (2.10.0)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.10.1)
 
 PLATFORMS
   ruby

--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -192,10 +192,12 @@ module Warden
       opts  = argument.is_a?(Hash) ? argument : { :scope => argument }
       scope = (opts[:scope] ||= @config.default_scope)
 
-      @users[scope] ||= begin
+      if @users.has_key?(scope)
+        @users[scope]
+      else
         user = session_serializer.fetch(scope)
         opts[:event] = :fetch
-        set_user(user, opts) if user
+        @users[scope] = user ? set_user(user, opts) : nil
       end
     end
 

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -417,6 +417,16 @@ describe Warden::Proxy do
       setup_rack(app).call(@env)
     end
 
+    it "should not fetch user twice" do
+      Warden::SessionSerializer.any_instance.should_receive(:fetch).once
+      app = lambda do |env|
+        env['warden'].user.should be_nil
+        env['warden'].user.should be_nil
+        valid_response
+      end
+      setup_rack(app).call(@env)
+    end
+
     describe "previously logged in" do
       before(:each) do
         @env['rack.session']['warden.user.default.key'] = "A Previous User"


### PR DESCRIPTION
avoid calling session_serializer.fetch everytime `user` is called, is also more symetric to the normal user lookup (we do not lookup the userid in the session/change the current user if we already found a user)

This is a nice performance boost for us, since every SessionSerializer.deserialize always hits our database

(Also adds a test for user-caching which did not produce an error when removed)
