### PR TITLE
Fix Rack Protocol implementation

### DIFF
--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -28,9 +28,9 @@ module Warden
     # If this is downstream from another warden instance, don't do anything.
     # :api: private
     def call(env) # :nodoc:
-      return @app.call(env) if env['warden'] && env['warden'].manager != self
+      return @app.call(env) if env['warden.env'] && env['warden.env'].manager != self
 
-      env['warden'] = Proxy.new(env, self)
+      env['warden.env'] = Proxy.new(env, self)
       result = catch(:warden) do
         @app.call(env)
       end
@@ -91,7 +91,7 @@ module Warden
   private
 
     def intercept_401?(env)
-      config[:intercept_401] && !env['warden'].custom_failure?
+      config[:intercept_401] && !env['warden.env'].custom_failure?
     end
 
     # When a request is unauthenticated, here's where the processing occurs.
@@ -103,7 +103,7 @@ module Warden
         opts[:action] || 'unauthenticated'
       end
 
-      proxy  = env['warden']
+      proxy  = env['warden.env']
       result = options[:result] || proxy.result
 
       case result

--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -59,13 +59,13 @@ module Warden
     #
     # Example:
     #   # Clear all strategies for the configured default_scope
-    #   env['warden'].clear_strategies_cache!
+    #   env['warden.env'].clear_strategies_cache!
     #
     #   # Clear all strategies for the :admin scope
-    #   env['warden'].clear_strategies_cache!(:scope => :admin)
+    #   env['warden.env'].clear_strategies_cache!(:scope => :admin)
     #
     #   # Clear password strategy for the :admin scope
-    #   env['warden'].clear_strategies_cache!(:password, :scope => :admin)
+    #   env['warden.env'].clear_strategies_cache!(:password, :scope => :admin)
     #
     # :api: public
     def clear_strategies_cache!(*args)
@@ -97,7 +97,7 @@ module Warden
     #   opts - an options hash that contains the :scope of the user to check
     #
     # Example:
-    #   env['warden'].authenticate(:password, :basic, :scope => :sudo)
+    #   env['warden.env'].authenticate(:password, :basic, :scope => :sudo)
     #
     # :api: public
     def authenticate(*args)
@@ -120,7 +120,7 @@ module Warden
     # and rendered through the +failure_app+
     #
     # Example
-    #   env['warden'].authenticate!(:password, :scope => :publisher) # throws if it cannot authenticate
+    #   env['warden.env'].authenticate!(:password, :scope => :publisher) # throws if it cannot authenticate
     #
     # :api: public
     def authenticate!(*args)
@@ -137,7 +137,7 @@ module Warden
     #   scope - the scope to check for authentication. Defaults to default_scope
     #
     # Example:
-    #   env['warden'].authenticated?(:admin)
+    #   env['warden.env'].authenticated?(:admin)
     #
     # :api: public
     def authenticated?(scope = @config.default_scope)
@@ -187,19 +187,19 @@ module Warden
     #
     # Example:
     #   # without scope (default user)
-    #   env['warden'].user
+    #   env['warden.env'].user
     #
     #   # with scope
-    #   env['warden'].user(:admin)
+    #   env['warden.env'].user(:admin)
     #
     #   # as a Hash
-    #   env['warden'].user(:scope => :admin)
+    #   env['warden.env'].user(:scope => :admin)
     #
     #   # with default scope and run_callbacks option
-    #   env['warden'].user(:run_callbacks => false)
+    #   env['warden.env'].user(:run_callbacks => false)
     #
     #  # with a scope and run_callbacks option
-    #  env['warden'].user(:scope => :admin, :run_callbacks => true)
+    #  env['warden.env'].user(:scope => :admin, :run_callbacks => true)
     #
     # :api: public
     def user(argument = {})
@@ -223,10 +223,10 @@ module Warden
     #
     # Example
     #  # default scope
-    #  env['warden'].session[:foo] = "bar"
+    #  env['warden.env'].session[:foo] = "bar"
     #
     #  # :sudo scope
-    #  env['warden'].session(:sudo)[:foo] = "bar"
+    #  env['warden.env'].session(:sudo)[:foo] = "bar"
     #
     # :api: public
     def session(scope = @config.default_scope)
@@ -242,13 +242,13 @@ module Warden
     #
     # Example:
     #  # Logout everyone and clear the session
-    #  env['warden'].logout
+    #  env['warden.env'].logout
     #
     #  # Logout the default user but leave the rest of the session alone
-    #  env['warden'].logout(:default)
+    #  env['warden.env'].logout(:default)
     #
     #  # Logout the :publisher and :admin user
-    #  env['warden'].logout(:publisher, :admin)
+    #  env['warden.env'].logout(:publisher, :admin)
     #
     # :api: public
     def logout(*scopes)

--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -83,7 +83,7 @@ module Warden
       # Access to the errors object.
       # :api: public
       def errors
-        @env['warden'].errors
+        @env['warden.env'].errors
       end
 
       # Cause the processing of the strategies to stop and cascade no further

--- a/spec/helpers/request_helper.rb
+++ b/spec/helpers/request_helper.rb
@@ -10,7 +10,7 @@ module Warden::Spec
     end
 
     def setup_rack(app = nil, opts = {}, &block)
-      app ||= block if block_given?
+      app ||= Rack::Lint.new(block) if block_given?
 
       opts[:failure_app]         ||= failure_app
       opts[:default_strategies]  ||= [:password]

--- a/spec/warden/authenticated_data_store_spec.rb
+++ b/spec/warden/authenticated_data_store_spec.rb
@@ -14,13 +14,13 @@ describe "authenticated data store" do
 
   it "should store data for the default scope" do
     app = lambda do |e|
-      e['warden'].authenticate(:pass)
-      e['warden'].authenticate(:pass, :scope => :foo)
-      e['warden'].should be_authenticated
-      e['warden'].should be_authenticated(:foo)
+      e['warden.env'].authenticate(:pass)
+      e['warden.env'].authenticate(:pass, :scope => :foo)
+      e['warden.env'].should be_authenticated
+      e['warden.env'].should be_authenticated(:foo)
 
       # Store the data for :default
-      e['warden'].session[:key] = "value"
+      e['warden.env'].session[:key] = "value"
       valid_response
     end
     setup_rack(app).call(@env)
@@ -30,7 +30,7 @@ describe "authenticated data store" do
 
   it "should store data for the foo user" do
     app = lambda do |e|
-      e['warden'].session(:foo)[:key] = "value"
+      e['warden.env'].session(:foo)[:key] = "value"
       valid_response
     end
     setup_rack(app).call(@env)
@@ -39,8 +39,8 @@ describe "authenticated data store" do
 
   it "should store the data seperately" do
     app = lambda do |e|
-      e['warden'].session[:key] = "value"
-      e['warden'].session(:foo)[:key] = "another value"
+      e['warden.env'].session[:key] = "value"
+      e['warden.env'].session(:foo)[:key] = "another value"
       valid_response
     end
     setup_rack(app).call(@env)
@@ -50,9 +50,9 @@ describe "authenticated data store" do
 
   it "should clear the foo scoped data when foo logs out" do
     app = lambda do |e|
-      e['warden'].session[:key] = "value"
-      e['warden'].session(:foo)[:key] = "another value"
-      e['warden'].logout(:foo)
+      e['warden.env'].session[:key] = "value"
+      e['warden.env'].session(:foo)[:key] = "another value"
+      e['warden.env'].logout(:foo)
       valid_response
     end
     setup_rack(app).call(@env)
@@ -62,9 +62,9 @@ describe "authenticated data store" do
 
   it "should clear out the default data when :default logs out" do
     app = lambda do |e|
-      e['warden'].session[:key] = "value"
-      e['warden'].session(:foo)[:key] = "another value"
-      e['warden'].logout(:default)
+      e['warden.env'].session[:key] = "value"
+      e['warden.env'].session(:foo)[:key] = "another value"
+      e['warden.env'].logout(:default)
       valid_response
     end
     setup_rack(app).call(@env)
@@ -74,9 +74,9 @@ describe "authenticated data store" do
 
   it "should clear out all data when a general logout is performed" do
     app = lambda do |e|
-      e['warden'].session[:key] = "value"
-      e['warden'].session(:foo)[:key] = "another value"
-      e['warden'].logout
+      e['warden.env'].session[:key] = "value"
+      e['warden.env'].session(:foo)[:key] = "another value"
+      e['warden.env'].logout
       valid_response
     end
     setup_rack(app).call(@env)
@@ -88,10 +88,10 @@ describe "authenticated data store" do
     @env['rack.session']['warden.user.bar.key'] = "bar user"
 
     app = lambda do |e|
-      e['warden'].session[:key] = "value"
-      e['warden'].session(:foo)[:key] = "another value"
-      e['warden'].session(:bar)[:key] = "yet another"
-      e['warden'].logout(:bar, :default)
+      e['warden.env'].session[:key] = "value"
+      e['warden.env'].session(:foo)[:key] = "another value"
+      e['warden.env'].session(:bar)[:key] = "yet another"
+      e['warden.env'].logout(:bar, :default)
       valid_response
     end
     setup_rack(app).call(@env)
@@ -103,7 +103,7 @@ describe "authenticated data store" do
   it "should not store data for a user who is not logged in" do
     @env['rack.session']
     app = lambda do |e|
-      e['warden'].session(:not_here)[:key] = "value"
+      e['warden.env'].session(:not_here)[:key] = "value"
       valid_response
     end
 

--- a/spec/warden/hooks_spec.rb
+++ b/spec/warden/hooks_spec.rb
@@ -35,12 +35,12 @@ describe "standard authentication hooks" do
       RAM.after_set_user{|u,a,o| a.env['warden.spec.hook.bar'] = "run bar"}
       RAM.after_set_user{|u,a,o| a.logout}
       app = lambda do |e|
-        e['warden'].set_user("foo")
+        e['warden.env'].set_user("foo")
         valid_response
       end
       env = env_with_params
       setup_rack(app).call(env)
-      env['warden'].user.should be_nil
+      env['warden.env'].user.should be_nil
       env['warden.spec.hook.foo'].should == "run foo"
       env['warden.spec.hook.bar'].should == "run bar"
     end
@@ -48,7 +48,7 @@ describe "standard authentication hooks" do
     it "should not run the event specified with except" do
       RAM.after_set_user(:except => :set_user){|u,a,o| fail}
       app = lambda do |e|
-        e['warden'].set_user("foo")
+        e['warden.env'].set_user("foo")
         valid_response
       end
       env = env_with_params
@@ -58,7 +58,7 @@ describe "standard authentication hooks" do
     it "should only run the event specified with only" do
       RAM.after_set_user(:only => :set_user){|u,a,o| fail}
       app = lambda do |e|
-        e['warden'].authenticate(:pass)
+        e['warden.env'].authenticate(:pass)
         valid_response
       end
       env = env_with_params
@@ -71,7 +71,7 @@ describe "standard authentication hooks" do
       RAM.prepend_after_set_user{|u,a,o| a.env['warden.spec.order'] << 1}
       app = lambda do |e|
         e['warden.spec.order'] = []
-        e['warden'].set_user("foo")
+        e['warden.env'].set_user("foo")
         valid_response
       end
       env = env_with_params
@@ -85,7 +85,7 @@ describe "standard authentication hooks" do
         RAM.after_authentication{|u,a,o| a.env['warden.spec.hook.paz'] = "run paz"}
         RAM.after_authentication{|u,a,o| o[:event].should == :authentication }
         app = lambda do |e|
-          e['warden'].authenticate(:pass)
+          e['warden.env'].authenticate(:pass)
           valid_response
         end
         env = env_with_params
@@ -97,7 +97,7 @@ describe "standard authentication hooks" do
       it "should not be invoked on default after_set_user scenario" do
         RAM.after_authentication{|u,a,o| fail}
         app = lambda do |e|
-          e['warden'].set_user("foo")
+          e['warden.env'].set_user("foo")
           valid_response
         end
         env = env_with_params
@@ -110,7 +110,7 @@ describe "standard authentication hooks" do
         RAM.prepend_after_authentication{|u,a,o| a.env['warden.spec.order'] << 1}
         app = lambda do |e|
           e['warden.spec.order'] = []
-          e['warden'].authenticate(:pass)
+          e['warden.env'].authenticate(:pass)
           valid_response
         end
         env = env_with_params
@@ -122,12 +122,12 @@ describe "standard authentication hooks" do
         RAM.after_set_user{|u,a,o| a.logout}
 
         app = lambda do |e|
-          e['warden'].authenticate(:pass)
+          e['warden.env'].authenticate(:pass)
           valid_response
         end
         env = env_with_params
         setup_rack(app).call(env)
-        env['warden'].authenticated?.should be_false
+        env['warden.env'].authenticated?.should be_false
       end
     end
 
@@ -139,7 +139,7 @@ describe "standard authentication hooks" do
         env = env_with_params
         setup_rack(lambda { |e| valid_response }).call(env)
         env['rack.session']['warden.user.default.key'] = "Foo"
-        env['warden'].user.should == "Foo"
+        env['warden.env'].user.should == "Foo"
         env['warden.spec.hook.baz'].should == 'run baz'
         env['warden.spec.hook.paz'].should == 'run paz'
       end
@@ -147,7 +147,7 @@ describe "standard authentication hooks" do
       it "should not be invoked on default after_set_user scenario" do
         RAM.after_fetch{|u,a,o| fail}
         app = lambda do |e|
-          e['warden'].set_user("foo")
+          e['warden.env'].set_user("foo")
           valid_response
         end
         env = env_with_params
@@ -159,7 +159,7 @@ describe "standard authentication hooks" do
         env = env_with_params
         setup_rack(lambda { |e| valid_response }).call(env)
         env['rack.session']['warden.user.default.key'] = nil
-        env['warden'].user.should be_nil
+        env['warden.env'].user.should be_nil
       end
 
       it "should run filters in the given order" do
@@ -169,7 +169,7 @@ describe "standard authentication hooks" do
         app = lambda do |e|
           e['warden.spec.order'] = []
           e['rack.session']['warden.user.default.key'] = "Foo"
-          e['warden'].user
+          e['warden.env'].user
           valid_response
         end
         env = env_with_params
@@ -195,7 +195,7 @@ describe "standard authentication hooks" do
       env = env_with_params
       setup_rack(lambda { |e| valid_response }).call(env)
       env['rack.session']['warden.user.default.key'] = "Foo"
-      env['warden'].user.should == "Foo"
+      env['warden.env'].user.should == "Foo"
     end
 
     it "should be called if fetched user is nil" do
@@ -203,7 +203,7 @@ describe "standard authentication hooks" do
       RAM.after_failed_fetch{|u,a,o| calls += 1 }
       env = env_with_params
       setup_rack(lambda { |e| valid_response }).call(env)
-      env['warden'].user.should be_nil
+      env['warden.env'].user.should be_nil
       calls.should == 1
     end
   end
@@ -232,7 +232,7 @@ describe "standard authentication hooks" do
     it "should run each before_failure hooks before failing" do
       RAM.before_failure{|e,o| e['warden.spec.before_failure.foo'] = "foo"}
       RAM.before_failure{|e,o| e['warden.spec.before_failure.bar'] = "bar"}
-      app = lambda{|e| e['warden'].authenticate!(:failz); valid_response}
+      app = lambda{|e| e['warden.env'].authenticate!(:failz); valid_response}
       env = env_with_params
       setup_rack(app).call(env)
       env['warden.spec.before_failure.foo'].should == "foo"
@@ -245,7 +245,7 @@ describe "standard authentication hooks" do
       RAM.prepend_before_failure{|e,o| e['warden.spec.order'] << 1}
       app = lambda do |e|
         e['warden.spec.order'] = []
-        e['warden'].authenticate!(:failz)
+        e['warden.env'].authenticate!(:failz)
         valid_response
       end
       env = env_with_params
@@ -278,10 +278,10 @@ describe "standard authentication hooks" do
     it "should run each before_logout hook before logout is run" do
       RAM.before_logout{|u,a,o| a.env['warden.spec.hook.lorem'] = "run lorem"}
       RAM.before_logout{|u,a,o| a.env['warden.spec.hook.ipsum'] = "run ipsum"}
-      app = lambda{|e| e['warden'].authenticate(:pass); valid_response}
+      app = lambda{|e| e['warden.env'].authenticate(:pass); valid_response}
       env = env_with_params
       setup_rack(app).call(env)
-      env['warden'].logout
+      env['warden.env'].logout
       env['warden.spec.hook.lorem'].should == 'run lorem'
       env['warden.spec.hook.ipsum'].should == 'run ipsum'
     end
@@ -291,8 +291,8 @@ describe "standard authentication hooks" do
       RAM.before_logout(:scope => [:scope2]){|u,a,o| a.env["warden.spec.hook.b"] << :scope2 }
 
       app = lambda do |e|
-        e['warden'].authenticate(:pass, :scope => :scope1)
-        e['warden'].authenticate(:pass, :scope => :scope2)
+        e['warden.env'].authenticate(:pass, :scope => :scope1)
+        e['warden.env'].authenticate(:pass, :scope => :scope2)
         valid_response
       end
       env = env_with_params
@@ -300,11 +300,11 @@ describe "standard authentication hooks" do
       env["warden.spec.hook.b"] ||= []
       setup_rack(app).call(env)
 
-      env['warden'].logout(:scope1)
+      env['warden.env'].logout(:scope1)
       env['warden.spec.hook.a'].should == [:scope1]
       env['warden.spec.hook.b'].should == []
 
-      env['warden'].logout(:scope2)
+      env['warden.env'].logout(:scope2)
       env['warden.spec.hook.a'].should == [:scope1]
       env['warden.spec.hook.b'].should == [:scope2]
     end
@@ -315,8 +315,8 @@ describe "standard authentication hooks" do
       RAM.prepend_before_logout{|u,a,o| a.env['warden.spec.order'] << 1}
       app = lambda do |e|
         e['warden.spec.order'] = []
-        e['warden'].authenticate(:pass)
-        e['warden'].logout
+        e['warden.env'].authenticate(:pass)
+        e['warden.env'].logout
         valid_response
       end
       env = env_with_params

--- a/spec/warden/strategies/base_spec.rb
+++ b/spec/warden/strategies/base_spec.rb
@@ -84,7 +84,7 @@ describe Warden::Strategies::Base do
       end
     end
     env = env_with_params
-    env['warden'] = Warden::Proxy.new(env, Warden::Manager.new({}))
+    env['warden.env'] = Warden::Proxy.new(env, Warden::Manager.new({}))
     strategy = RAS[:foobar].new(env)
     strategy._run!
     strategy.errors.on(:foo).should == ["foo has an error"]

--- a/spec/warden/test/helpers_spec.rb
+++ b/spec/warden/test/helpers_spec.rb
@@ -10,8 +10,8 @@ describe Warden::Test::Helpers do
     login_as user
     app = lambda{|e|
       $captures << :run
-      e['warden'].should be_authenticated
-      e['warden'].user.should == "A User"
+      e['warden.env'].should be_authenticated
+      e['warden.env'].user.should == "A User"
       valid_response
     }
     setup_rack(app).call(env_with_params)
@@ -23,7 +23,7 @@ describe Warden::Test::Helpers do
     login_as user, :scope => :foo_scope
     app = lambda{|e|
       $captures << :run
-      w = e['warden']
+      w = e['warden.env']
       w.should be_authenticated(:foo_scope)
       w.user(:foo_scope).should == {:some => "user"}
     }
@@ -38,7 +38,7 @@ describe Warden::Test::Helpers do
     login_as foo_user, :scope => :foo
     app = lambda{|e|
       $captures << :run
-      w = e['warden']
+      w = e['warden.env']
       w.user.should == "A user"
       w.user(:foo).should == "A foo user"
       w.should be_authenticated
@@ -55,7 +55,7 @@ describe Warden::Test::Helpers do
     login_as foo, :scope => :foo
     app = lambda{|e|
       $captures << :run
-      w = e['warden']
+      w = e['warden.env']
       w.user.should == "A user"
       w.user(:foo).should == "Foo"
       w.logout
@@ -75,7 +75,7 @@ describe Warden::Test::Helpers do
     login_as foo, :scope => :foo
     app = lambda{|e|
       $captures << :run
-      w = e['warden']
+      w = e['warden.env']
       w.logout :foo
       w.user.should == "A User"
       w.user(:foo).should be_nil


### PR DESCRIPTION
From [Rack SPEC](http://rack.rubyforge.org/doc/SPEC.html) :
- The Body must respond to each and must only yield String values.
- The keys must contain at least one dot, and should be prefixed uniquely.
  > 'warden' => 'warden.env'

Obviously, this breaks compatibility with existing applications.

Please note that the new key is a proposal.
