### PR TITLE
add explicit rspec require in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'warden'
 
 require 'rubygems'
 require 'rack'
+require 'rspec'
 
 Dir[File.join(File.dirname(__FILE__), "helpers", "**/*.rb")].each do |f|
   require f


### PR DESCRIPTION
It is required for automatic building of debian packages from the gem file.
