### PR TITLE
A FailureApp should know its failure message

### DIFF
--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -118,6 +118,7 @@ module Warden
       when :custom
         proxy.custom_response
       else
+        options[:message] ||= proxy.message
         call_failure_app(env, options)
       end
     end

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -48,6 +48,16 @@ describe Warden::Manager do
         result.last.should eq(["You Fail!"])
       end
 
+      it "should set the message from the winning strategy in warden.options hash" do
+        env = env_with_params("/", {})
+        app = lambda do |_env|
+          _env['warden'].authenticate(:failz)
+          throw(:warden)
+        end
+        setup_rack(app, :failure_app => @fail_app).call(env) # TODO: What is @fail_app?
+        env["warden.options"][:message].should eq("The Fails Strategy Has Failed You")
+      end
+
       it "should render the failure app when there's a failure" do
         app = lambda do |e|
           throw(:warden, :action => :unauthenticated) unless e['warden'].authenticated?(:failz)


### PR DESCRIPTION
In my humble opinion, a FailureApp should know why someone woke it up.

For instance, in this example in devise: https://github.com/plataformatec/devise/blob/v3.3.0/lib/devise/strategies/database_authenticatable.rb#L17, it seems to be that `:not_found_in_database` is a useful piece of information that the FailureApp should have access to.
