### PR TITLE
Strategies shouldn't store by default

### DIFF
--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -101,7 +101,7 @@ module Warden
       # Checks to see if a strategy should result in a permanent login
       # :api: public
       def store?
-        true
+        false
       end
 
       # A simple method to return from authenticate! if you want to ignore this strategy


### PR DESCRIPTION
I was surprised to learn that my strategy was opening another avenue of access to my application. At minimum the `#store?` method should be documented in [Strategies](https://github.com/hassox/warden/wiki/Strategies), but I also believe that this behavior goes against the grain of "default deny", a security fundamental.

I saw a reference in #111, but no explanation of the reasoning behind the decision.
