### PR TITLE
Update to rack >= 2.0.6 due to XSS security vulnerability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-== Version 1.2.8 / Not released
+== Version 1.2.8 / 2018-11-15
 * Bugfix: Flips two lines to allow scopes authenticating from another without stepping on each other's toes. (PR #144)
+* Update `rack` dependency to >= 2.0.6 due to security vulnerability
 * Internal: Add Rubocop Lint checking
 * Internal: Update RSpec to use `.rspec` file
-* Internal: Update `rack` dependency to 2.x
 
 == Version 1.2.7 / 2016-10-12
 * Added 'frozen_string_literal' comment, bump ruby to 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'rack', '~> 2.0'
+gem 'rack', '>= 2.0.6'
 
 group :test do
   gem 'rspec', '~>3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     warden (1.2.8)
-      rack (>= 1.0)
+      rack (>= 2.0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    rack (2.0.3)
+    rack (2.0.6)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rake (12.1.0)
@@ -30,11 +30,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rack (~> 2.0)
+  rack (>= 2.0.6)
   rack-test
   rake
   rspec (~> 3)
   warden!
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.17.1

--- a/warden.gemspec
+++ b/warden.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--charset=UTF-8"]
   spec.require_paths = ["lib"]
   spec.rubyforge_project = %q{warden}
-  spec.add_dependency "rack", ">= 1.0"
+  spec.add_dependency "rack", ">= 2.0.6"
 end


### PR DESCRIPTION
This will release 1.2.8 into the wild. It is a big jump in rack version, but we are unable to let a depedency be 1.6.11+ OR 2.0.6+ at the same time.

CVE details:

> There is a possible XSS vulnerability in Rack before 2.0.6 and 1.6.11. Carefully crafted requests can impact the data returned by the `scheme` method on `Rack::Request`. Applications that expect the scheme to be limited to 'http' or 'https' and do not escape the return value could be vulnerable to an XSS attack. Note that applications using the normal escaping mechanisms provided by Rails may not impacted, but applications that bypass the escaping mechanisms, or do not use them may be vulnerable.