### PR TITLE
Set `winning_strategy` when `:warden` is thrown

### DIFF
--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -365,9 +365,12 @@ module Warden
       (strategies || args).each do |name|
         strategy = _fetch_strategy(name, scope)
         next unless strategy && !strategy.performed? && strategy.valid?
+        catch(:warden) do
+          _update_winning_strategy(strategy, scope)
+        end
 
         strategy._run!
-        self.winning_strategy = @winning_strategies[scope] = strategy
+        _update_winning_strategy(strategy, scope)
         break if strategy.halted?
       end
     end
@@ -381,6 +384,11 @@ module Warden
       else
         raise "Invalid strategy #{name}"
       end
+    end
+
+    # Updates the winning strategy for a given scope
+    def _update_winning_strategy(strategy, scope)
+      self.winning_strategy = @winning_strategies[scope] = strategy
     end
   end # Proxy
 

--- a/spec/helpers/strategies/failz.rb
+++ b/spec/helpers/strategies/failz.rb
@@ -5,5 +5,6 @@ Warden::Strategies.add(:failz) do
     request.env['warden.spec.strategies'] ||= []
     request.env['warden.spec.strategies'] << :failz
     fail!("The Fails Strategy Has Failed You")
+    throw :warden
   end
 end


### PR DESCRIPTION
Per Issue #171, when `:warden` thrown during authentication, a winning
strategy is not set. This commit resolves this issue by catching the
thrown symbol and setting the current strategy as `self`'s winning
strategy.

Thanks to @f1sherman for introducing the failing spec that was used to
resolve this!