### PR TITLE
gemspec: rubyforge_project is removed

### DIFF
--- a/warden.gemspec
+++ b/warden.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
   end
   spec.rdoc_options = ["--charset=UTF-8"]
   spec.require_paths = ["lib"]
-  spec.rubyforge_project = %q{warden}
   spec.add_dependency "rack", ">= 2.0.6"
 end


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.