### PR TITLE
Avoid warning on uninitialized instance variable

### DIFF
--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -45,6 +45,7 @@ module Warden
         @env, @scope = env, scope
         @status, @headers = nil, {}
         @halted, @performed = false, false
+        @result = nil
       end
 
       # The method that is called from above. This method calls the underlying authenticate! method


### PR DESCRIPTION
I ran the specs with `RUBYOPT=-W2 bundle exec rake`, and there was an avoidable warning, which this PR fix.

Ran on :

```
$ ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin19]
```