### PR TITLE
Gemfile: Use a newer RSpec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,19 +12,19 @@ GEM
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rake (13.0.1)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
 
 PLATFORMS
   ruby
@@ -36,5 +36,3 @@ DEPENDENCIES
   rspec (~> 3)
   warden!
 
-BUNDLED WITH
-   1.17.1


### PR DESCRIPTION
  - this avoids warnings output from RSpec, hehe
  - this also drops the BUNDLED_WITH, which makes the file run also with latest Bundler