### PR TITLE
Test and development cleanups

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ pkg
 
 *.gem
 Gemfile.lock
+
+.ruby-version
+.ruby-gemset

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -1060,6 +1060,12 @@ describe "dynamic default_strategies" do
       ::Warden.asset_paths = @asset_regex
     end
 
+    around do |example|
+      asset_paths = ::Warden.asset_paths
+      example.run
+      ::Warden.instance_variable_set(:@asset_paths, asset_paths)
+    end
+
     it "should return true if PATH_INFO is in asset list" do
       env = env_with_params('/assets/fun.gif')
       setup_rack(success_app).call(env)

--- a/spec/warden/test/helpers_spec.rb
+++ b/spec/warden/test/helpers_spec.rb
@@ -83,10 +83,4 @@ RSpec.describe Warden::Test::Helpers do
     setup_rack(app).call(env_with_params)
     expect($captures).to eq([:run])
   end
-
-  describe "#asset_paths" do
-    it "should default asset_paths to anything asset path regex" do
-      expect(Warden.asset_paths).to eq([/^\/assets\//]      )
-    end
-  end
 end

--- a/spec/warden/test/test_mode_spec.rb
+++ b/spec/warden/test/test_mode_spec.rb
@@ -71,4 +71,10 @@ RSpec.describe Warden::Test::WardenHelpers do
       expect($captures).to eq([])
     end
   end
+
+  describe "#asset_paths" do
+    it "should default asset_paths to anything asset path regex" do
+      expect(Warden.asset_paths).to eq([/^\/assets\//])
+    end
+  end
 end


### PR DESCRIPTION
- Test against Ruby 3.1 too.
- Ignore .ruby-version and .ruby-gemset files.
- Global settings cleanup in asset_request? tests.
- The asset_paths method is in Warden::Test::WardenHelpers.