### PR TITLE
Fix test with `rack` >= 3 and test with Ruby > 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Tests
 on: [push, pull_request]
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
         ruby: [ '2.5', '2.6', '2.7', '3.0' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ gem 'pry'
 group :test do
   gem 'rspec', '~> 3'
   gem 'rack-test'
+  gem 'rack-session'
 end

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 # frozen_string_literal: true
+
+require 'rack/session'
+
 RSpec.describe Warden::Proxy do
   before(:all) do
     load_strategies


### PR DESCRIPTION
Since rack 3.0.0, `Rack::Session` was extracted to a separate gem (see: https://github.com/rack/rack/pull/1805).

Add the `rack-session` gem to the Gemfile and require it in the test.

Add more Ruby versions (`3.1`, `3.2`, `3.3`) to the CI.

Update GitHub action [actions/checkout](https://github.com/actions/checkout) to v4.