### PR TITLE
Fix build 💚 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,6 +7,11 @@ jobs:
     strategy:
       matrix:
         ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
+        gemfile:
+          - "rack_2"
+          - "rack_3"
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake'
 gem 'pry'
 
-group :test do
-  gem 'rspec', '~> 3'
-  gem 'rack-test'
-  gem 'rack-session'
-end

--- a/gemfiles/rack_2.gemfile
+++ b/gemfiles/rack_2.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rack", "~> 2.2"
+
+gemspec path: "../"

--- a/gemfiles/rack_3.gemfile
+++ b/gemfiles/rack_3.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rack", "~> 3.0"
+
+gemspec path: "../"

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Warden::Manager do
         result = @app.call(env_with_params)
         expect(result.status).to eq(201)
         expect(result.body).to eq(['body'])
-        expect(result.header['Content-Type']).to eq('text/plain')
+        expect(result.headers['Content-Type']).to eq('text/plain')
       end
     end
 

--- a/warden.gemspec
+++ b/warden.gemspec
@@ -22,4 +22,9 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
   spec.add_dependency "rack", ">= 2.2.3"
+
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", "~> 3"
+  spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "rack-session"
 end


### PR DESCRIPTION
- Use `Rack::Response#headers` instead of `Rack::Response#header`. header is deprecated and removed in version 3.1.
- Add support for testing with multiple versions of Rack (2 and 3)