### PR TITLE
Adds support for multiple messages

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,69 @@
+VERSION 0.7
+
+# This allows one to change the running Ruby version with:
+#
+# `earthly --allow-privileged +rspec --EARTHLY_RUBY_VERSION=2.5`
+ARG --global EARTHLY_RUBY_VERSION=3.3
+# This allows one to change the imported Gemfile from the `gemfiles` folder:
+#
+# `earthly --allow-privileged +rspec --EARTHLY_RACK_VERSION=2`
+ARG --global EARTHLY_RACK_VERSION=3
+# Of course you can mix both!
+
+FROM ruby:$EARTHLY_RUBY_VERSION
+WORKDIR /gem
+
+deps:
+    COPY gemfiles/rack_$EARTHLY_RACK_VERSION.gemfile /gem/Gemfile
+    COPY *.gemspec /gem
+    COPY lib/warden/version.rb /gem/lib/warden/version.rb
+
+    RUN apt update \
+        && apt install --yes \
+                       --no-install-recommends \
+                       build-essential \
+                       git \
+        && sed -i 's/path: "\.\.\/"//g' /gem/Gemfile \
+        && bundle install --jobs $(nproc)
+
+    SAVE ARTIFACT /usr/local/bundle bundler
+    SAVE ARTIFACT /gem/Gemfile Gemfile
+    SAVE ARTIFACT /gem/Gemfile.lock Gemfile.lock
+
+dev:
+    RUN apt update \
+        && apt install --yes \
+                       --no-install-recommends \
+                       git
+
+    COPY +deps/bundler /usr/local/bundle
+    COPY +deps/Gemfile /gem/Gemfile
+    COPY +deps/Gemfile.lock /gem/Gemfile.lock
+
+    COPY *.gemspec /gem
+    COPY Rakefile /gem
+
+    COPY lib/ /gem/lib/
+    COPY spec/ /gem/spec/
+    COPY .rspec /gem/
+
+    ENTRYPOINT ["bundle", "exec"]
+    CMD ["rake"]
+
+    SAVE IMAGE wardencommunity/warden:latest
+
+#
+# This target runs the test suite.
+#
+# Use the following command in order to run the tests suite:
+# earthly --allow-privileged +rspec
+#
+# See the above `EARTHLY_RUBY_VERSION` and `EARTHLY_RACK_VERSION` arguments.
+rspec:
+    FROM earthly/dind:alpine
+
+    COPY docker-compose.yml ./
+
+    WITH DOCKER --load wardencommunity/warden:latest=+dev
+        RUN docker-compose run --rm gem
+    END

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+name: warden
+
+services:
+  # docker compose run --rm gem [rspec [path to spec file]]
+  gem:
+    image: wardencommunity/warden:latest

--- a/lib/warden/manager.rb
+++ b/lib/warden/manager.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
 # frozen_string_literal: true
+# encoding: utf-8
 require 'warden/hooks'
 require 'warden/config'
 
@@ -118,14 +118,19 @@ module Warden
       proxy  = env['warden']
       result = options[:result] || proxy.result
 
+      if options.key?(:message)
+        warn "NOTE: Sending :message to redirect! is deprecated, use :messages instead"
+        options[:messages] = Array(options.delete(:message))
+      end
+
       case result
       when :redirect
-        body = proxy.message || "You are being redirected to #{proxy.headers['Location']}"
-        [proxy.status, proxy.headers, [body]]
+        body = proxy.messages || ["You are being redirected to #{proxy.headers['Location']}"]
+        [proxy.status, proxy.headers, Array(body)]
       when :custom
         proxy.custom_response
       else
-        options[:message] ||= proxy.message
+        options[:messages] ||= proxy.messages
         call_failure_app(env, options)
       end
     end

--- a/lib/warden/proxy.rb
+++ b/lib/warden/proxy.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
 # frozen_string_literal: true
+# encoding: utf-8
 
 module Warden
   class UserNotSet < RuntimeError; end
@@ -288,9 +288,16 @@ module Warden
 
     # Proxy through to the authentication strategy to find out the message that was generated.
     # :api: public
-    def message
-      winning_strategy && winning_strategy.message
+    def messages
+      winning_strategy && winning_strategy.messages
     end
+
+    def message
+      messages
+    end
+
+    extend Gem::Deprecate
+    deprecate :message, :messages, 2026, 1
 
     # Provides a way to return a 401 without warden deferring to the failure app
     # The result is a direct passthrough of your own response

--- a/lib/warden/strategies/base.rb
+++ b/lib/warden/strategies/base.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
 # frozen_string_literal: true
+# encoding: utf-8
 module Warden
   module Strategies
     # A strategy is a place where you can put logic related to authentication. Any strategy inherits
@@ -30,7 +30,7 @@ module Warden
     #
     class Base
       # :api: public
-      attr_accessor :user, :message
+      attr_accessor :user, :messages
 
       # :api: private
       attr_accessor :result, :custom_response
@@ -126,7 +126,7 @@ module Warden
       def success!(user, message = nil)
         halt!
         @user = user
-        @message = message
+        add_message message
         @result = :success
       end
 
@@ -136,14 +136,14 @@ module Warden
       # :api: public
       def fail!(message = "Failed to Login")
         halt!
-        @message = message
+        add_message message
         @result = :failure
       end
 
       # Causes the strategy to fail, but not halt.  The strategies will cascade after this failure and warden will check the next strategy.  The last strategy to fail will have it's message displayed.
       # :api: public
       def fail(message = "Failed to Login")
-        @message = message
+        add_message message
         @result = :failure
       end
 
@@ -163,7 +163,12 @@ module Warden
         headers["Location"] << "?" << Rack::Utils.build_query(params) unless params.empty?
         headers["Content-Type"] = opts[:content_type] || 'text/plain'
 
-        @message = opts[:message] || "You are being redirected to #{headers["Location"]}"
+        if opts.key?(:message)
+          warn "NOTE: Sending :message to redirect! is deprecated, use :messages instead."
+          opts[:messages] = opts.delete(:message)
+        end
+
+        add_message opts[:messages] || "You are being redirected to #{headers["Location"]}"
         @result = :redirect
 
         headers["Location"]
@@ -177,6 +182,9 @@ module Warden
         @result = :custom
       end
 
+      def add_message(messages)
+        @messages = Array(@messages) | Array(messages)
+      end
     end # Base
   end # Strategies
 end # Warden

--- a/spec/warden/manager_spec.rb
+++ b/spec/warden/manager_spec.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
 # frozen_string_literal: true
+# encoding: utf-8
 RSpec.describe Warden::Manager do
   it "should insert a Proxy object into the rack env" do
     env = env_with_params
@@ -39,7 +39,7 @@ RSpec.describe Warden::Manager do
           throw(:warden)
         end
         setup_rack(app).call(env)
-        expect(env["warden.options"][:message]).to eq("The Fails Strategy Has Failed You")
+        expect(env["warden.options"][:messages]).to eq(["The Fails Strategy Has Failed You"])
       end
 
       it "should render the failure app when there's a failure" do
@@ -174,7 +174,7 @@ RSpec.describe Warden::Manager do
       it "should redirect with a message" do
         RAS.add(:foobar) do
           def authenticate!
-            redirect!("/foo/bar", {:foo => "bar"}, :message => "custom redirection message")
+            redirect!("/foo/bar", {:foo => "bar"}, :messages => ["custom redirection message"])
           end
         end
         result = @app.call(env_with_params)

--- a/spec/warden/proxy_spec.rb
+++ b/spec/warden/proxy_spec.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
 # frozen_string_literal: true
+# encoding: utf-8
 
 require 'rack/session'
 
@@ -645,7 +645,7 @@ RSpec.describe Warden::Proxy do
     end
   end
 
-  describe "messages" do
+  describe "message" do
     it "should allow access to the failure message" do
       failure = lambda do |e|
         [401, {"Content-Type" => "text/plain"}, [e['warden'].message]]
@@ -654,10 +654,34 @@ RSpec.describe Warden::Proxy do
         e['warden'].authenticate! :failz
       end
       result = setup_rack(app, :failure_app => failure).call(@env)
-      expect(result.last).to eq(["The Fails Strategy Has Failed You"])
+      expect(result.last).to eq([["The Fails Strategy Has Failed You"]])
+    end
+
+    it "should deprecate accessing the failure message" do
+      failure = lambda do |e|
+        [401, {"Content-Type" => "text/plain"}, [e['warden'].message]]
+      end
+      app = lambda do |e|
+        e['warden'].authenticate! :failz
+      end
+      expect {
+        setup_rack(app, :failure_app => failure).call(@env)
+      }.to output(/NOTE: Warden::Proxy#message is deprecated; use messages instead. It will be removed on or after 2026-01./).to_stderr
     end
 
     it "should allow access to the success message" do
+      success = lambda do |e|
+        [200, {"Content-Type" => "text/plain"}, [e['warden'].messages]]
+      end
+      app = lambda do |e|
+        e['warden'].authenticate! :pass_with_message
+        success.call(e)
+      end
+      result = setup_rack(app).call(@env)
+      expect(result.last).to eq([["The Success Strategy Has Accepted You"]])
+    end
+
+    it "should deprecate accessing the success message" do
       success = lambda do |e|
         [200, {"Content-Type" => "text/plain"}, [e['warden'].message]]
       end
@@ -665,13 +689,47 @@ RSpec.describe Warden::Proxy do
         e['warden'].authenticate! :pass_with_message
         success.call(e)
       end
-      result = setup_rack(app).call(@env)
-      expect(result.last).to eq(["The Success Strategy Has Accepted You"])
+      expect {
+        setup_rack(app).call(@env)
+      }.to output(/NOTE: Warden::Proxy#message is deprecated; use messages instead. It will be removed on or after 2026-01./).to_stderr
     end
 
     it "should not die when accessing a message from a source where no authentication has occurred" do
       app = lambda do |e|
         [200, {"Content-Type" => "text/plain"}, [e['warden'].message]]
+      end
+      result = setup_rack(app).call(@env)
+      expect(result[2]).to eq([nil])
+    end
+  end
+
+  describe "messages" do
+    it "should allow access to the failure messages" do
+      failure = lambda do |e|
+        [401, {"Content-Type" => "text/plain"}, [e['warden'].messages]]
+      end
+      app = lambda do |e|
+        e['warden'].authenticate! :failz
+      end
+      result = setup_rack(app, :failure_app => failure).call(@env)
+      expect(result.last).to eq([["The Fails Strategy Has Failed You"]])
+    end
+
+    it "should allow access to the success message" do
+      success = lambda do |e|
+        [200, {"Content-Type" => "text/plain"}, [e['warden'].messages]]
+      end
+      app = lambda do |e|
+        e['warden'].authenticate! :pass_with_message
+        success.call(e)
+      end
+      result = setup_rack(app).call(@env)
+      expect(result.last).to eq([["The Success Strategy Has Accepted You"]])
+    end
+
+    it "should not die when accessing a message from a source where no authentication has occurred" do
+      app = lambda do |e|
+        [200, {"Content-Type" => "text/plain"}, [e['warden'].messages]]
       end
       result = setup_rack(app).call(@env)
       expect(result[2]).to eq([nil])

--- a/spec/warden/strategies/base_spec.rb
+++ b/spec/warden/strategies/base_spec.rb
@@ -1,5 +1,5 @@
-# encoding: utf-8
 # frozen_string_literal: true
+# encoding: utf-8
 require 'spec_helper'
 
 describe Warden::Strategies::Base do
@@ -69,12 +69,12 @@ describe Warden::Strategies::Base do
   it "should allow you to set a message" do
     RAS.add(:foobar) do
       def authenticate!
-        self.message = "foo message"
+        self.messages = ["foo message"]
       end
     end
     strategy = RAS[:foobar].new(env_with_params)
     strategy._run!
-    expect(strategy.message).to eq("foo message")
+    expect(strategy.messages).to eq(["foo message"])
   end
 
   it "should provide access to the errors" do
@@ -112,7 +112,6 @@ describe Warden::Strategies::Base do
       str._run!
       expect(str).not_to be_halted
     end
-
   end
 
   describe "pass" do
@@ -172,13 +171,38 @@ describe Warden::Strategies::Base do
       str = RAS[:foobar].new(env_with_params)
       str._run!
       expect(str.headers["Location"]).to eq("/foo/bar?foo=bar")
-      expect(str.message).to eq("You are being redirected foo")
+      expect(str.messages).to eq(["You are being redirected foo"])
+    end
+
+    it "should warn when using message instead of messages" do
+      RAS.add(:foobar) do
+        def authenticate!
+          redirect!("/foo/bar", {:foo => "bar"}, :message => "You are being redirected foo")
+        end
+      end
+
+      expect {
+        str = RAS[:foobar].new(env_with_params)
+        str._run!
+      }.to output(/NOTE: Sending :message to redirect! is deprecated, use :messages instead./).to_stderr
+    end
+
+    it "should allow you to set messages" do
+      RAS.add(:foobar) do
+        def authenticate!
+          redirect!("/foo/bar", {:foo => "bar"}, :messages => "You are being redirected foo")
+        end
+      end
+      str = RAS[:foobar].new(env_with_params)
+      str._run!
+      expect(str.headers["Location"]).to eq("/foo/bar?foo=bar")
+      expect(str.messages).to eq(["You are being redirected foo"])
     end
 
     it "should set the action as :redirect" do
       RAS.add(:foobar) do
         def authenticate!
-          redirect!("/foo/bar", {:foo => "bar"}, :message => "foo")
+          redirect!("/foo/bar", {:foo => "bar"}, :messages => "foo")
         end
       end
       str = RAS[:foobar].new(env_with_params)
@@ -188,7 +212,6 @@ describe Warden::Strategies::Base do
   end
 
   describe "failure" do
-
     before(:each) do
       RAS.add(:hard_fail) do
         def authenticate!
@@ -217,7 +240,7 @@ describe Warden::Strategies::Base do
 
     it "should allow you to set a message when failing hard" do
       @hard._run!
-      expect(@hard.message).to eq("You are not cool enough")
+      expect(@hard.messages).to eq(["You are not cool enough"])
     end
 
     it "should set the action as :failure when failing hard" do
@@ -237,7 +260,7 @@ describe Warden::Strategies::Base do
 
     it "should allow you to set a message when failing soft" do
       @soft._run!
-      expect(@soft.message).to eq("You are too soft")
+      expect(@soft.messages).to eq(["You are too soft"])
     end
 
     it "should set the action as :failure when failing soft" do
@@ -267,7 +290,7 @@ describe Warden::Strategies::Base do
 
     it "should allow you to set a message when succeeding" do
       @str._run!
-      expect(@str.message).to eq("Welcome to the club!")
+      expect(@str.messages).to eq(["Welcome to the club!"])
     end
 
     it "should store the user" do
@@ -310,4 +333,36 @@ describe Warden::Strategies::Base do
     end
   end
 
+  describe "add_message" do
+    before do
+      RAS.add(:foobar) do
+        def authenticate!
+          success!("foo")
+        end
+      end
+    end
+
+    let(:multiple_messages) { ['This is message one', 'This is message two'] }
+    let(:single_message) { 'That is a success!' }
+    let(:strategy) { RAS[:foobar].new(env_with_params) }
+
+    it "should allow adding a single message" do
+      strategy.add_message(single_message)
+
+      expect(strategy.messages).to eql([single_message])
+    end
+
+    it "should allow adding a list of messages" do
+      strategy.add_message(multiple_messages)
+
+      expect(strategy.messages).to eql(multiple_messages)
+    end
+
+    it "should append messages" do
+      strategy.add_message(multiple_messages)
+      strategy.add_message(single_message)
+
+      expect(strategy.messages).to eql(multiple_messages | [single_message])
+    end
+  end
 end


### PR DESCRIPTION
This PR allow one to pass a single message or a list of messages to the `fail` and `success` methods.

This will allow the Device gem to pass those messages to warden, and get them displayed on the login pages.

Our use case is the following : We are adding a "delayable" strategy which adds exponential delay between login failures with an information message, and when a single login try remain, we want to show the alert telling about the delay before the user will be able to retry to login, and the alert that only one try remain before his account is being locked.

This PR also adds an `Earthlyfile` and a `docker-compose.yml` file for convinience to run Rspec with Docker and [Earthly](https://earthly.dev/) with a single command:
```
earthly --allow-privileged +rspec
```
_I can even update your Github workflow in order to use Earthly so that we truly benefit from a complete isolation avoiding to get tests failing on the CI, but not locally since Earthly runs Docker in Docker to the tests._