### PR TITLE
fix: exclude `.github` directory from published gem

### DIFF
--- a/warden.gemspec
+++ b/warden.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     "README.md"
   ]
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(\.github|test|spec|features)/})
   end
   spec.require_paths = ["lib"]
   spec.add_dependency "rack", ">= 2.2.3"


### PR DESCRIPTION
This'll make things about 12k smaller 🙂 