### PR TITLE
Add skip_background_requests option to test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+* Add `Warden.skip_background_requests` test mode option to keep `on_next_request` blocks queued while browser background requests (fetch/XHR) go through, so that only a page load consumes them
+
 ## Version 1.2.9 / 2020-08-31
 * Avoid warning on uninitialized instance variable (#188)
 * Bump rack to 2.2.3 (#190)

--- a/lib/warden.rb
+++ b/lib/warden.rb
@@ -29,13 +29,15 @@ module Warden
   # This will provide a number of methods.
   # Warden.on_next_request(&blk) - captures a block which is yielded the warden proxy on the next request
   # Warden.test_reset! - removes any captured blocks that would have been executed on the next request
+  # Warden.skip_background_requests = true - keeps captured blocks queued while browser background
+  #   requests (fetch/XHR) go through, so that only a page load consumes them
   #
   # Warden.test_reset! should be called in after blocks for rspec, or teardown methods for Test::Unit
   def self.test_mode!
     unless Warden::Test::WardenHelpers === Warden
       Warden.extend Warden::Test::WardenHelpers
       Warden::Manager.on_request do |proxy|
-        unless proxy.asset_request?
+        unless proxy.asset_request? || Warden._skip_background_request?(proxy.env)
           while blk = Warden._on_next_request.shift
             blk.call(proxy)
           end

--- a/lib/warden/test/warden_helpers.rb
+++ b/lib/warden/test/warden_helpers.rb
@@ -5,6 +5,19 @@ module Warden
 
   module Test
     module WardenHelpers
+      # Detects requests that a browser sends in the background (fetch/XHR data
+      # calls), as opposed to page loads. Only a browser attaches Sec-Fetch-Mode,
+      # and JavaScript cannot forge or remove it, so requests made directly by a
+      # test client (e.g. rack-test) never match and keep the default behaviour.
+      # Among browser requests, an Accept header without text/html separates
+      # background data calls from page loads: both a classic navigation and a
+      # Turbo/Hotwire fetch ask for html, a data call does not.
+      # @see Warden::Test::WardenHelpers#skip_background_requests=
+      # @api public
+      BROWSER_BACKGROUND_REQUEST = lambda do |env|
+        !env['HTTP_SEC_FETCH_MODE'].to_s.empty? && !env['HTTP_ACCEPT'].to_s.include?('text/html')
+      end
+
       # Returns list of regex objects that match paths expected to be an asset
       # @see Warden::Proxy#asset_request?
       # @api public
@@ -24,6 +37,34 @@ module Warden
       # @api public
       def on_next_request(&blk)
         _on_next_request << blk
+      end
+
+      # Tells test mode to keep on_next_request blocks queued while browser
+      # background requests (fetch/XHR data calls) go through, so that only a
+      # page load consumes them. Without this, a background request still in
+      # flight when the test logs in can consume the queued login: the session
+      # cookie travels in that response, and if the browser cancels the request
+      # while navigating away, the cookie is discarded with it and the next page
+      # is served unauthenticated.
+      #
+      # Accepts +true+ to enable the default detection (BROWSER_BACKGROUND_REQUEST),
+      # a callable that receives the rack env to customize it, or +false+ / +nil+
+      # to disable it (the default, preserving the previous behaviour).
+      #
+      # @example
+      #   Warden.skip_background_requests = true
+      #   Warden.skip_background_requests = ->(env) { env['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest' }
+      # @api public
+      attr_accessor :skip_background_requests
+
+      # Whether the request should not consume the on_next_request blocks,
+      # according to the skip_background_requests setting.
+      # @api private
+      def _skip_background_request?(env)
+        return false if !skip_background_requests
+
+        detector = skip_background_requests == true ? BROWSER_BACKGROUND_REQUEST : skip_background_requests
+        detector.call(env)
       end
 
       # resets wardens tests

--- a/spec/warden/test/test_mode_spec.rb
+++ b/spec/warden/test/test_mode_spec.rb
@@ -71,4 +71,61 @@ RSpec.describe Warden::Test::WardenHelpers do
       expect($captures).to eq([])
     end
   end
+
+  context "background requests" do
+    after do
+      Warden.skip_background_requests = false
+    end
+
+    def background_request_env(path = "/search.json")
+      env_with_params(path, {}, 'HTTP_SEC_FETCH_MODE' => 'cors', 'HTTP_ACCEPT' => 'application/json, */*')
+    end
+
+    def page_load_env(path = "/")
+      env_with_params(path, {}, 'HTTP_SEC_FETCH_MODE' => 'navigate', 'HTTP_ACCEPT' => 'text/html,application/xhtml+xml')
+    end
+
+    it "should execute on_next_request blocks on background requests by default" do
+      app = setup_rack(@app)
+      Warden.on_next_request{|_w| $captures << :first }
+      app.call(background_request_env)
+      expect($captures).to eq([:first])
+    end
+
+    it "should keep on_next_request blocks queued until a page load when skip_background_requests is enabled" do
+      Warden.skip_background_requests = true
+      app = setup_rack(@app)
+      Warden.on_next_request{|_w| $captures << :first }
+      app.call(background_request_env)
+      expect($captures).to eq([])
+      app.call(page_load_env)
+      expect($captures).to eq([:first])
+    end
+
+    it "should execute on_next_request blocks on browser requests asking for html" do
+      Warden.skip_background_requests = true
+      app = setup_rack(@app)
+      Warden.on_next_request{|_w| $captures << :first }
+      app.call(page_load_env)
+      expect($captures).to eq([:first])
+    end
+
+    it "should execute on_next_request blocks on requests without Sec-Fetch-Mode" do
+      Warden.skip_background_requests = true
+      app = setup_rack(@app)
+      Warden.on_next_request{|_w| $captures << :first }
+      app.call(env_with_params("/api/things", {}, 'HTTP_ACCEPT' => 'application/json'))
+      expect($captures).to eq([:first])
+    end
+
+    it "should accept a callable to customize the detection" do
+      Warden.skip_background_requests = lambda{|env| env['PATH_INFO'] == "/background" }
+      app = setup_rack(@app)
+      Warden.on_next_request{|_w| $captures << :first }
+      app.call(env_with_params("/background"))
+      expect($captures).to eq([])
+      app.call(env_with_params("/regular"))
+      expect($captures).to eq([:first])
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Warden.test_mode!` drains the `on_next_request` queue (where `login_as` stores the pending login) on the first request that is not an asset request. That contract predates browsers making background data calls: in a system test driving a real browser (Capybara + Selenium/Cuprite), pages routinely fire fetch/XHR requests, which are not asset requests, so they can consume the queued login.

This opens a race producing flaky, hard-to-diagnose failures:

1. The test calls `login_as(user)` — the login is queued.
2. The test navigates to a new page while a background fetch from the previous page is still in flight.
3. That fetch reaches the server first and consumes the login; the session cookie travels in its response.
4. The navigation cancels the in-flight fetch, so the browser discards the response — and its `Set-Cookie` with it.
5. The new page is requested without a session cookie and served unauthenticated.

The existing knob, `Warden.asset_paths`, cannot express a fix: it only matches `PATH_INFO`, so it would require enumerating every data endpoint of the app, and it would also affect requests made directly by test clients. Related reports: teamcapybara/capybara#702, teamcapybara/capybara#1441.

## Solution

An opt-in test mode option:

```ruby
Warden.skip_background_requests = true
```

When enabled, browser background requests no longer drain the `on_next_request` queue: the queued login stays put until a page load consumes it — and a page load's response is never discarded by the browser, so the session cookie always lands.

Detection is header-based and self-limiting:

- `Sec-Fetch-Mode` is attached by real browsers to every request and cannot be forged or removed by JavaScript; requests from test clients (e.g. rack-test) never carry it, so integration tests keep the current behaviour even with the option enabled.
- Among browser requests, an `Accept` header without `text/html` separates data calls from page loads: both a classic navigation and a Turbo/Hotwire fetch ask for html, a data call does not.

The detection can be customized by assigning a callable that receives the rack env:

```ruby
Warden.skip_background_requests = ->(env) { env['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest' }
```

The option defaults to `false`: nothing changes unless it is enabled, and nothing changes outside test mode.

We have been running this exact detection in CardTrader's test suite (as a `Warden::Proxy` patch) and it removed a whole class of flaky authentication failures under parallel test execution.

This patch was developed with the help of Claude Code.
